### PR TITLE
adding setting that allows users to specify the number of folders they wish to display

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -34,6 +34,11 @@ module.exports = {
             default: true,
             title: 'Match tabs with same name',
             description: 'When opened 2 and more files with same name but from different folders it will styled always(even if name doesn\'t match pattern index.* ).',
+        },
+        numberOfFolders: {
+          type: 'integer',
+          default: 1,
+          description: 'Number of folders to display'
         }
     },
     /**
@@ -84,6 +89,14 @@ module.exports = {
                     tabs[tab].checkTab();
                 }
             }
+        }));
+
+        this.subscriptions.add(atom.config.onDidChange('tab-foldername-index.numberOfFolders', ({newValue}) => {
+          for (const tab in tabs) {
+              if (tabs.hasOwnProperty(tab)) {
+                  tabs[tab].checkTab();
+              }
+          }
         }));
     },
 

--- a/lib/tab.js
+++ b/lib/tab.js
@@ -149,7 +149,8 @@ class Tab {
         }
 
         let folder = this.pane.getPath().split('/');
-        folder = folder[folder.length - 2];
+        const numOfFolders = atom.config.get('tab-foldername-index.numberOfFolders');
+        folder = folder.slice(0, -1).slice(-numOfFolders).join('/');
 
         for (let $element of this.$elements) {
             let $tabWrapper = generateTabTitle(folder, name);

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -15,6 +15,7 @@ describe "Tab-foldername-index main", ->
 
   beforeEach ->
     atom.config.set('tab-foldername-index.equalsNamesEnabled', true)
+    atom.config.set('tab-foldername-index.numberOfFolders', 1)
     workspaceElement = atom.views.getView atom.workspace
     jasmine.attachToDOM workspaceElement
 

--- a/spec/tab-spec.coffee
+++ b/spec/tab-spec.coffee
@@ -26,6 +26,7 @@ $element = null
 describe "tab-foldername-index", ->
   beforeEach ->
     atom.config.set('tab-foldername-index.equalsNamesEnabled', true)
+    atom.config.set('tab-foldername-index.numberOfFolders', 1)
 
   afterEach ->
     mapNames.clear()
@@ -284,3 +285,23 @@ describe "tab-foldername-index", ->
 
     tab = new Tab mochPaneInvalid
     expect(tab).toBeInstanceOf Tab
+
+
+  it "should render only one folder name", ->
+    $element = createMochHTMLtab()
+
+    tab = new Tab mochPaneValid, [$element]
+    tab.setEnabled()
+
+    expect(tab.$elements[0]).toBe $element
+    expect($element.querySelector(".tab-foldername-index__folder").textContent).toBe "work"
+
+  it "should render two folder names", ->
+    atom.config.set('tab-foldername-index.numberOfFolders', 2)
+    $element = createMochHTMLtab()
+
+    tab = new Tab mochPaneValid, [$element]
+    tab.setEnabled()
+
+    expect(tab.$elements[0]).toBe $element
+    expect($element.querySelector(".tab-foldername-index__folder").textContent).toBe "Users/work"


### PR DESCRIPTION
As the default is set to 1, the default behaviour is the same. I added a setting which allows users to specify how many folders they wish to display.