### PR TITLE
[Feature] Add support for file icons

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ module.exports = {
     },
 
     /**
-     * Runs when close tab or destroed package
+     * Runs when close tab or destroyed package
      * @param {Number} id
      */
     handleTabRemove(id) {

--- a/lib/tab.js
+++ b/lib/tab.js
@@ -21,7 +21,7 @@ function div(params) {
  * @param {String} file
  * @return {HTMLElement}
  */
-function generateTabTitle(folder, file) {
+function generateTabTitle(folder, file, initialClasses) {
     let $block = div({
         className: CLASS_NAME
     });
@@ -33,13 +33,17 @@ function generateTabTitle(folder, file) {
         className: `${CLASS_NAME}__file`,
         textContent: file
     });
-    let $wrapper = div({
-        className: `${CLASS_NAME}__wrapper`
+    let $textWrapper = div({
+        className: `${CLASS_NAME}__text-wrapper`
+    });
+    let $flexWrapper = div({
+        className: `${CLASS_NAME}__flex-wrapper ${initialClasses}`
     });
 
-    $wrapper.appendChild($folderBlock);
-    $wrapper.appendChild($fileBlock);
-    $block.appendChild($wrapper);
+    $textWrapper.appendChild($folderBlock);
+    $textWrapper.appendChild($fileBlock);
+    $flexWrapper.appendChild($textWrapper);
+    $block.appendChild($flexWrapper);
     return $block;
 }
 
@@ -152,14 +156,16 @@ class Tab {
         folder = folder[folder.length - 2];
 
         for (let $element of this.$elements) {
-            let $tabWrapper = generateTabTitle(folder, name);
+            const $title = $element.querySelector('.title');
+            const initialClasses = $title.className.replace(`${CLASS_NAME}__original`, '')
+
+            let $tabWrapper = generateTabTitle(folder, name, initialClasses);
             let $oldTabWrapper = $element.querySelector(`.${CLASS_NAME}`);
 
             if ($oldTabWrapper) {
                 $oldTabWrapper.remove();
             }
 
-            const $title = $element.querySelector('.title');
             $title.parentNode.appendChild($tabWrapper);
 
             $title.classList.add(`${CLASS_NAME}__original`);

--- a/styles/main.less
+++ b/styles/main.less
@@ -5,12 +5,18 @@
 @import "ui-variables";
 
 .tab-foldername-index {
-    line-height: 13px;
-    padding: 0.3rem 1rem 0;
+    line-height: 1;
+    height: 100%;
     text-align: center;
-    width: 100%;
 
-    &__wrapper {
+    &__flex-wrapper {
+        align-items: center;
+        display: flex;
+        height: 100%;
+        justify-content: center;
+    }
+
+    &__text-wrapper {
         display: inline-block;
         white-space: nowrap;
         max-width: 100%;
@@ -23,8 +29,8 @@
         width: 100%;
     }
 
-    &__folder {
-        font-weight: bold;
+    &__file {
+        opacity: 0.4;
     }
 
     &__original {
@@ -36,15 +42,24 @@
     }
 
     .status-added + & {
-        color: @syntax-color-added
+        color: @syntax-color-added;
     }
 
     .status-modified + & {
-        color: @syntax-color-modified
+        color: @syntax-color-modified;
     }
 
     .status-ignored + & {
         font-weight: normal;
-        opacity: 0.6
+        opacity: 0.6;
     }
+
+    &__flex-wrapper.icon .tab-foldername-index__text-wrapper {
+      max-width: ~"calc(100% - 1.516666667em)"; // `em` width to match `:before` icon size
+    }
+}
+
+// Overwrite unecessary `:before` icon top positioning
+.tab-bar .tab .title.title.tab-foldername-index__flex-wrapper::before {
+    top: 0;
 }


### PR DESCRIPTION
Update tab template and styles to support displaying file icons via the [`file-icons`](https://atom.io/packages/file-icons) package.
The `atom-tab-foldername-index` package works with or without `file-icons` enabled.

- Update tab template to include original tab classes, and thus any icons.
- Update styles to properly align and size icon, folder name, and file name.
- Repair comment typo.


### Renderings
##### Without Icons
<img width="805" alt="without-icons" src="https://user-images.githubusercontent.com/438664/29250369-0390d198-8007-11e7-8368-f9182ce198b0.png">

##### With Icons
<img width="802" alt="with-icons" src="https://user-images.githubusercontent.com/438664/29250367-009ee696-8007-11e7-927a-f0b7f20d2d1f.png">

##### With Long Title
<img width="795" alt="with-long-title" src="https://user-images.githubusercontent.com/438664/29252165-ce0b2368-8027-11e7-850c-bef816b028a1.png">
