### PR TITLE
Use path.sep instead of hardcoded '/'

### DIFF
--- a/lib/tab.js
+++ b/lib/tab.js
@@ -1,4 +1,5 @@
 const mapNames = require('./mapNames');
+const pathSep = require('path').sep;
 
 /**
  * Creates div element
@@ -167,9 +168,9 @@ class Tab {
             return;
         }
 
-        let folder = this.pane.getPath().split('/');
+        let folder = this.pane.getPath().split(pathSep);
         const numOfFolders = atom.config.get('tab-foldername-index.numberOfFolders');
-        folder = folder.slice(folder.length - numOfFolders - 1, -1).join('/');
+        folder = folder.slice(folder.length - numOfFolders - 1, -1).join(pathSep);
 
         for (let $element of this.$elements) {
             const $title = $element.querySelector('.title');


### PR DESCRIPTION
Makes this extension work on Windows as well.
Don't know if it ever worked and broke in some update of Atom, but this fix works on Atom v1.21.0-beta0, should work on v1.20 as well.