### PR TITLE
Add option to always show folder name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -35,6 +35,12 @@ module.exports = {
             title: 'Match tabs with same name',
             description: 'When opened 2 and more files with same name but from different folders it will styled always(even if name doesn\'t match pattern index.* ).',
         },
+        alwaysShowFolder: {
+            type: 'boolean',
+            default: true,
+            title: 'Always show folder name',
+            description: '',
+        },
         numberOfFolders: {
           type: 'integer',
           default: 1,

--- a/lib/tab.js
+++ b/lib/tab.js
@@ -157,15 +157,17 @@ class Tab {
     checkTab() {
         const name = this.pane.getTitle();
 
-        if (
-            this.disabled ||
-            (
-                !regExpIndexName.test(name) &&
-                (!atom.config.get('tab-foldername-index.equalsNamesEnabled') || !mapNames.hasReapeatedNames(name))
-            )
-        ) {
-            this.clearTab();
-            return;
+        if(!atom.config.get('tab-foldername-index.alwaysShowFolder')){
+          if (
+              this.disabled ||
+              (
+                  !regExpIndexName.test(name) &&
+                  (!atom.config.get('tab-foldername-index.equalsNamesEnabled') || !mapNames.hasReapeatedNames(name))
+              )
+          ) {
+              this.clearTab();
+              return;
+          }
         }
 
         let folder = this.pane.getPath().split(pathSep);

--- a/styles/main.less
+++ b/styles/main.less
@@ -35,7 +35,7 @@
     }
 
     &__file {
-        opacity: 0.4;
+        opacity: 0.7;
     }
 
     &__original {


### PR DESCRIPTION
I usually forget which file I have open, and they're all named index.js so I don't know what I'm working on. To fix that, I added the option to always show the folder name.